### PR TITLE
fix: unrecognized invalid_argument when building on ArchLinux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <stdexcept>
 
 #include "parse.hpp"
 

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -1,6 +1,8 @@
 #include "parse.hpp"
 #include "lex.hpp"
 
+#include <stdexcept>
+
 namespace bb
 {
 


### PR DESCRIPTION
I'm not able to reproduce this since I don't have a machine set up
with ArchLinux, but it's likely that the <stdexcept> header is not
being imported for this files.

fixes #1