### PR TITLE
Catch2

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,4 +1,4 @@
 #define CATCH_CONFIG_MAIN
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>

--- a/test/test_ast.cpp
+++ b/test/test_ast.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "ast.hpp"
 

--- a/test/test_lex.cpp
+++ b/test/test_lex.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "lex.hpp"
 

--- a/test/test_parse.cpp
+++ b/test/test_parse.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "lex.hpp"
 #include "parse.hpp"


### PR DESCRIPTION
Update Catch headers. ```catch_all.hpp``` header will include all Catch headers. ```catch2/catch.hpp``` no longer exists.

But updating the headers causes a linker failure.